### PR TITLE
one possible fix for issue #39

### DIFF
--- a/geo_activity_playground/webui/templates/calendar.html.j2
+++ b/geo_activity_playground/webui/templates/calendar.html.j2
@@ -22,10 +22,13 @@
                 {% for year, month_data in monthly_distances.items() %}
                 <tr>
                     <td>{{ year }}</td>
-                    {% for month, distance in month_data.items() %}
+                    {% for month in range(1, 13) %}
                     <td align="right">
-                        {% if distance > 0 %}
+                        {% set distance = month_data[month] %}
+                        {% if distance %}
                         <a href="/calendar/{{ year }}/{{ month }}">{{ distance|int() }} km</a>
+                        {% else %}
+                        0 km
                         {% endif %}
                     </td>
                     {% endfor %}


### PR DESCRIPTION
This is my suggestion for a fix for Issue #39.
It fills the table by looping over all months. If the distance exists and is not 0, the previous behaviour is used (a link to that months calendar with the distance). Otherwise the entry is set to "0 km".

@martin-ueding I think you intended to not include any text for 0 km. Please feel free to change it again, but it looks odd to me.