### PR TITLE
Add elevation processing for GPX files

### DIFF
--- a/geo_activity_playground/core/activity_parsers.py
+++ b/geo_activity_playground/core/activity_parsers.py
@@ -212,9 +212,9 @@ def read_gpx_activity(path: pathlib.Path, open) -> pd.DataFrame:
                     time = dateutil.parser.parse(str(point.time))
                 assert isinstance(time, datetime.datetime)
                 time = time.astimezone(datetime.timezone.utc)
-                points.append((time, point.latitude, point.longitude))
+                points.append((time, point.latitude, point.longitude, point.elevation))
 
-    return pd.DataFrame(points, columns=["time", "latitude", "longitude"])
+    return pd.DataFrame(points, columns=["time", "latitude", "longitude",  "altitude"])
 
 
 def read_tcx_activity(path: pathlib.Path, opener) -> pd.DataFrame:


### PR DESCRIPTION
This PR adds support for elevation data in GPX files. There is a slight drawback for tracks without any elevation data. In this case a diagram with a straight line at 'null' is drawn. It would be better to just display a text like "no elevation data" instead.  