### PR TITLE
Handle fitdecode.exceptions.FitError during strava import

### DIFF
--- a/geo_activity_playground/core/activity_parsers.py
+++ b/geo_activity_playground/core/activity_parsers.py
@@ -7,6 +7,7 @@ import xml
 import charset_normalizer
 import dateutil.parser
 import fitdecode
+import fitdecode.exceptions
 import gpxpy
 import pandas as pd
 import tcxreader.tcxreader
@@ -42,7 +43,10 @@ def read_activity(path: pathlib.Path) -> tuple[ActivityMeta, pd.DataFrame]:
         except UnicodeDecodeError as e:
             raise ActivityParseError(f"Encoding issue") from e
     elif file_type == ".fit":
-        metadata, timeseries = read_fit_activity(path, opener)
+        try:
+            metadata, timeseries = read_fit_activity(path, opener)
+        except fitdecode.exceptions.FitError as e:
+            raise ActivityParseError(f"Error in FIT file") from e
     elif file_type == ".tcx":
         try:
             timeseries = read_tcx_activity(path, opener)

--- a/geo_activity_playground/core/activity_parsers.py
+++ b/geo_activity_playground/core/activity_parsers.py
@@ -47,6 +47,8 @@ def read_activity(path: pathlib.Path) -> tuple[ActivityMeta, pd.DataFrame]:
             metadata, timeseries = read_fit_activity(path, opener)
         except fitdecode.exceptions.FitError as e:
             raise ActivityParseError(f"Error in FIT file") from e
+        except KeyError as e:
+            raise ActivityParseError(f"Key error while parsing FIT file") from e
     elif file_type == ".tcx":
         try:
             timeseries = read_tcx_activity(path, opener)


### PR DESCRIPTION
Catch exception during fit file parsing and raise ActivityParseError, so that the activity with broken .fit file is skipped. 

Closes #134 