### PR TITLE
added tooltips to all charts

### DIFF
--- a/geo_activity_playground/webui/eddington_blueprint.py
+++ b/geo_activity_playground/webui/eddington_blueprint.py
@@ -186,5 +186,8 @@ def _get_eddington_number_history(meta: pd.DataFrame) -> dict:
         .encode(
             alt.X("date", title="Date"),
             alt.Y("eddington_number", title="Eddington number"),
+            [
+                alt.Tooltip("date", title="Date"),
+                alt.Tooltip("eddington_number", title="Eddington number")]
         )
     ).to_json(format="vega")

--- a/geo_activity_playground/webui/equipment_blueprint.py
+++ b/geo_activity_playground/webui/equipment_blueprint.py
@@ -41,6 +41,10 @@ def make_equipment_blueprint(
                 .encode(
                     alt.X("time", title="Date"),
                     alt.Y("total_distance_km", title="Cumulative distance / km"),
+                    tooltip=[
+                        alt.Tooltip("time:T", title="Date"),
+                        alt.Tooltip("total_distance_km:Q", title="Cumulative distance / km", format=".0f")
+                    ]
                 )
                 .interactive()
                 .to_json(format="vega")
@@ -61,6 +65,11 @@ def make_equipment_blueprint(
                         scale=make_kind_scale(repository.meta, config),
                         title="Kind",
                     ),
+                    tooltip=[
+                        alt.Tooltip("year(start):O", title="Year"),
+                        alt.Tooltip("sum(distance_km):Q", title="Distance / km", format=".0f"),
+                        alt.Tooltip("kind:N", title="Kind")
+                    ]
                 )
                 .to_json(format="vega")
             )
@@ -78,6 +87,10 @@ def make_equipment_blueprint(
                         title="Kind",
                     ),
                     alt.Y("sum(distance_km)", title="Distance / km"),
+                    tooltip=[
+                        alt.Tooltip("kind:N", title="Kind"),
+                        alt.Tooltip("sum(distance_km):Q", title="Distance / km", format=".0f")
+                    ]
                 )
                 .to_json(format="vega")
             )

--- a/geo_activity_playground/webui/summary_blueprint.py
+++ b/geo_activity_playground/webui/summary_blueprint.py
@@ -163,6 +163,13 @@ def plot_monthly_distance(meta: pd.DataFrame, kind_scale: alt.Scale) -> str:
             alt.Y("sum(distance_km)", title="Distance / km"),
             alt.Color("kind", scale=kind_scale, title="Kind"),
             alt.Column("year(start):O", title="Year"),
+            [
+                alt.Tooltip("yearmonthdate(start)", title="Date"),
+                alt.Tooltip(
+                    "sum(distance_km)", format=".1f", title="Total distance / km"
+                ),
+                alt.Tooltip("count(distance_km)", title="Number of activities"),
+            ],
         )
         .resolve_axis(x="independent")
         .to_json(format="vega")
@@ -180,7 +187,7 @@ def plot_yearly_distance(year_kind_total: pd.DataFrame, kind_scale: alt.Scale) -
             [
                 alt.Tooltip("year:O", title="Year"),
                 alt.Tooltip("kind", title="Kind"),
-                alt.Tooltip("distance_km", title="Distance / km"),
+                alt.Tooltip("distance_km", title="Distance / km", format=".1f"),
             ],
         )
         .to_json(format="vega")
@@ -210,7 +217,7 @@ def plot_year_cumulative(df: pd.DataFrame) -> str:
             [
                 alt.Tooltip("week", title="Week"),
                 alt.Tooltip("iso_year:N", title="Year"),
-                alt.Tooltip("distance_km", title="Distance / km"),
+                alt.Tooltip("distance_km", title="Distance / km", format=".1f"),
             ],
         )
         .interactive()
@@ -267,7 +274,7 @@ def plot_weekly_distance(df: pd.DataFrame, kind_scale: alt.Scale) -> str:
             [
                 alt.Tooltip("year_week", title="Year and Week"),
                 alt.Tooltip("kind", title="Kind"),
-                alt.Tooltip("distance_km", title="Distance / km"),
+                alt.Tooltip("distance_km", title="Distance / km", format=".1f"),
             ],
         )
         .to_json(format="vega")


### PR DESCRIPTION
Hallo Martin,

ich teste gerade wie ich meinen Rechner mit dieser gesamten GitHub-Fork-PR-Geschichte aufsetze, wenn dies hier also nicht ganz funktioniert, sei also nicht böse :) 

Was das hier produzieren soll ist, dass alle Charts, die noch keine Tooltips haben, welche bekommen und dass alle Tooltips, die bislang deutlich zu viele Nachkommastellen anzeigen, diese auf ein sinnvolles Maß reduzieren.

Gruß
Michael