### PR TITLE
Force text rendering of square planner arrows

### DIFF
--- a/geo_activity_playground/webui/templates/square_planner/index.html.j2
+++ b/geo_activity_playground/webui/templates/square_planner/index.html.j2
@@ -13,16 +13,16 @@
             <tr>
                 <td>
                     <a class="btn btn-primary"
-                        href="/square-planner/{{ zoom }}/{{ square_x-1 }}/{{ square_y-1 }}/{{ square_size+1 }}">↖</a>
+                        href="/square-planner/{{ zoom }}/{{ square_x-1 }}/{{ square_y-1 }}/{{ square_size+1 }}">↖&#xFE0E;</a>
                     <a class="btn btn-primary"
-                        href="/square-planner/{{ zoom }}/{{ square_x+1 }}/{{ square_y+1 }}/{{ square_size-1 }}">↘</a>
+                        href="/square-planner/{{ zoom }}/{{ square_x+1 }}/{{ square_y+1 }}/{{ square_size-1 }}">↘&#xFE0E;</a>
                 </td>
                 <td></td>
                 <td>
                     <a class="btn btn-primary"
-                        href="/square-planner/{{ zoom }}/{{ square_x }}/{{ square_y+1 }}/{{ square_size-1 }}">↙</a>
+                        href="/square-planner/{{ zoom }}/{{ square_x }}/{{ square_y+1 }}/{{ square_size-1 }}">↙&#xFE0E;</a>
                     <a class="btn btn-primary"
-                        href="/square-planner/{{ zoom }}/{{ square_x }}/{{ square_y-1 }}/{{ square_size+1 }}">↗</a>
+                        href="/square-planner/{{ zoom }}/{{ square_x }}/{{ square_y-1 }}/{{ square_size+1 }}">↗&#xFE0E;</a>
                 </td>
             </tr>
             <tr>
@@ -32,7 +32,7 @@
                         <tr>
                             <td>
                                 <a class="btn btn-primary"
-                                    href="/square-planner/{{ zoom }}/{{ square_x-1 }}/{{ square_y-1 }}/{{ square_size }}">↖</a>
+                                    href="/square-planner/{{ zoom }}/{{ square_x-1 }}/{{ square_y-1 }}/{{ square_size }}">↖&#xFE0E;</a>
                             </td>
                             <td>
                                 <a class="btn btn-primary"
@@ -40,7 +40,7 @@
                             </td>
                             <td>
                                 <a class="btn btn-primary"
-                                    href="/square-planner/{{ zoom }}/{{ square_x+1 }}/{{ square_y-1 }}/{{ square_size }}">↗</a>
+                                    href="/square-planner/{{ zoom }}/{{ square_x+1 }}/{{ square_y-1 }}/{{ square_size }}">↗&#xFE0E;</a>
                             </td>
                         </tr>
                         <tr>
@@ -57,7 +57,7 @@
                         <tr>
                             <td>
                                 <a class="btn btn-primary"
-                                    href="/square-planner/{{ zoom }}/{{ square_x-1 }}/{{ square_y+1 }}/{{ square_size }}">↙</a>
+                                    href="/square-planner/{{ zoom }}/{{ square_x-1 }}/{{ square_y+1 }}/{{ square_size }}">↙&#xFE0E;</a>
                             </td>
                             <td>
                                 <a class="btn btn-primary"
@@ -65,7 +65,7 @@
                             </td>
                             <td>
                                 <a class="btn btn-primary"
-                                    href="/square-planner/{{ zoom }}/{{ square_x+1 }}/{{ square_y+1 }}/{{ square_size }}">↘</a>
+                                    href="/square-planner/{{ zoom }}/{{ square_x+1 }}/{{ square_y+1 }}/{{ square_size }}">↘&#xFE0E;</a>
                             </td>
                         </tr>
                     </table>
@@ -75,16 +75,16 @@
             <tr>
                 <td>
                     <a class="btn btn-primary"
-                        href="/square-planner/{{ zoom }}/{{ square_x-1 }}/{{ square_y }}/{{ square_size+1 }}">↙</a>
+                        href="/square-planner/{{ zoom }}/{{ square_x-1 }}/{{ square_y }}/{{ square_size+1 }}">↙&#xFE0E;</a>
                     <a class="btn btn-primary"
-                        href="/square-planner/{{ zoom }}/{{ square_x+1 }}/{{ square_y }}/{{ square_size-1 }}">↗</a>
+                        href="/square-planner/{{ zoom }}/{{ square_x+1 }}/{{ square_y }}/{{ square_size-1 }}">↗&#xFE0E;</a>
                 </td>
                 <td></td>
                 <td>
                     <a class="btn btn-primary"
-                        href="/square-planner/{{ zoom }}/{{ square_x }}/{{ square_y }}/{{ square_size-1 }}">↖</a>
+                        href="/square-planner/{{ zoom }}/{{ square_x }}/{{ square_y }}/{{ square_size-1 }}">↖&#xFE0E;</a>
                     <a class="btn btn-primary"
-                        href="/square-planner/{{ zoom }}/{{ square_x }}/{{ square_y }}/{{ square_size+1 }}">↘</a>
+                        href="/square-planner/{{ zoom }}/{{ square_x }}/{{ square_y }}/{{ square_size+1 }}">↘&#xFE0E;</a>
                 </td>
             </tr>
         </table>


### PR DESCRIPTION
This fixes #230. I tried to replace the arrows but ran into problems on iOS with other unicode symbols. So I went back to [read up on unicode arrows](https://en.wikipedia.org/wiki/Arrows_(Unicode_block)) and learned that there is a modifier to force rendering in text font instead of emoji font.