### PR TITLE
Fix line color select label

### DIFF
--- a/geo_activity_playground/webui/templates/activity/show.html.j2
+++ b/geo_activity_playground/webui/templates/activity/show.html.j2
@@ -116,7 +116,7 @@
                 <label class="form-label">Line Color by</label>
                 <select class="form-select" aria-label="Line Color by" name="line_color_column" onchange="this.form.submit()">
                     {% for name, column in line_color_columns_avail.items() %}
-                    <option {% if name == line_color_column %} selected {% endif %} value="{{ name }}">{{ column.displayName }}</option>
+                    <option {% if name == line_color_column %} selected {% endif %} value="{{ name }}">{{ column.display_name }}</option>
                     {% endfor %}
                 </select>
             </form>


### PR DESCRIPTION
Fix for the label in the line-color select box in the activity page, it got lost in the "displayName -> display_name" change in the ColumnDescription class. Also changes some variable names in the eddington blueprint where I used camel case instead of snake case.