### PR TITLE
Fix timezone string case(`utc` -> `UTC`) in strava_checkout parser

### DIFF
--- a/geo_activity_playground/importers/strava_checkout.py
+++ b/geo_activity_playground/importers/strava_checkout.py
@@ -194,7 +194,7 @@ def import_from_strava_checkout(config: Config) -> None:
 
         start_datetime = dateutil.parser.parse(
             row["Activity Date"], dayfirst=dayfirst
-        ).replace(tzinfo=zoneinfo.ZoneInfo("utc"))
+        ).replace(tzinfo=zoneinfo.ZoneInfo("UTC"))
 
         activity_file = checkout_path / row["Filename"]
 


### PR DESCRIPTION
Fix timezone to be upper case in strava_checkout parser. 

Fixes #340 