### PR TITLE
fix typo in layer name

### DIFF
--- a/geo_activity_playground/webui/static/server-side-explorer.js
+++ b/geo_activity_playground/webui/static/server-side-explorer.js
@@ -44,7 +44,7 @@ let overlay_maps = {
         maxZoom: 19,
         attribution: map_tile_attribution
     }),
-    "Mising": L.tileLayer(`/explorer/${zoom}/tile/{z}/{x}/{y}.png?color_strategy=missing`, {
+    "Missing": L.tileLayer(`/explorer/${zoom}/tile/{z}/{x}/{y}.png?color_strategy=missing`, {
         maxZoom: 19,
         attribution: map_tile_attribution
     }),


### PR DESCRIPTION
This is just a fix for a typo in the map layers selection: "Mising" -> "Missing"