### PR TITLE
Automated docker image builds to Github Contaner Registry [Github Workflow]

### DIFF
--- a/.github/workflows/ghcr_build.yml
+++ b/.github/workflows/ghcr_build.yml
@@ -1,0 +1,47 @@
+name: Build and Push to GHCR
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from release or branch
+        id: vars
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            echo "tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.ref_name }}" == "main" || "${{ github.ref_name }}" == "master" ]]; then
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/geo-activity-playground:${{ steps.vars.outputs.tag }}


### PR DESCRIPTION
GHCR images make it easier to run geo-activity-playground with docker / docker compose with automatic updates to latest version.

Requires personal access token for repo, read:packages, write:packages to run and publish to ghcr.

Workflow runs upon change on main branch or new release
main -> :latest build
release -> version tagged release

You might want to adjust, so that :latest is the newest tagged release instead of git main.

---
Notice: Workflow was generated with the help of ChatGPT