### PR TITLE
update naming for "Bikerouter"

### DIFF
--- a/docs/satellite-elevation-isnt-helpful.md
+++ b/docs/satellite-elevation-isnt-helpful.md
@@ -26,7 +26,7 @@ So although that data is good, it isn't of the right kind for this project.
 
 ## LiDAR data
 
-Looking at [Bike Router](https://bikerouter.de/), which uses [Sonny’s LiDAR Digital Terrain Models of Europe](https://sonny.4lima.de/), has a bit more accuracy. There the bridge seems to have a better height:
+Looking at [Bikerouter](https://bikerouter.de/), which uses [Sonny’s LiDAR Digital Terrain Models of Europe](https://sonny.4lima.de/), has a bit more accuracy. There the bridge seems to have a better height:
 
 ![](images/elevation-from-bikerouter.png)
 

--- a/docs/using-maps-as-overlays.md
+++ b/docs/using-maps-as-overlays.md
@@ -35,9 +35,9 @@ And for the heatmap, you can use these:
 http://localhost:5000/heatmap/tile/{z}/{x}/{y}.png
 ```
 
-## Adding them to Bike Router
+## Adding them to Bikerouter
 
-Go to [Bike Router](https://bikerouter.de) and then you can add these as overlay layers. I show it here with the explorer tiles on zoom 17 with the "colorful cluster" strategy:
+Go to [Bikerouter](https://bikerouter.de) and then you can add these as overlay layers. I show it here with the explorer tiles on zoom 17 with the "colorful cluster" strategy:
 
 ![](images/bikerouter-overlay-2.png)
 

--- a/geo_activity_playground/webui/templates/segments/index.html.j2
+++ b/geo_activity_playground/webui/templates/segments/index.html.j2
@@ -53,7 +53,7 @@
 
 <h2>New Segment</h2>
 
-<p>To create a new segment, go to <a href="https://bikerouter.de/" target="_blank">Bike Router</a>, create the segment
+<p>To create a new segment, go to <a href="https://bikerouter.de/" target="_blank">Bikerouter</a>, create the segment
     that you want and download it as GeoJSON. Then upload that file with the form below.</p>
 
 <form method="post" enctype="multipart/form-data" action="{{ url_for('.new') }}">


### PR DESCRIPTION
This pull request just replaces some strings to correct the naming of *Bikerouter* in the app and the documentation ("Bike Router" → "Bikerouter").