### PR TITLE
Fix "key error" when processing tiles

### DIFF
--- a/geo_activity_playground/explorer/tile_visits.py
+++ b/geo_activity_playground/explorer/tile_visits.py
@@ -519,13 +519,16 @@ def _compute_cluster_evolution(
 
     rows = []
     for index, row in tqdm(
-        tiles.iloc[s.cluster_start :].iterrows(),
+        tiles.iterrows(),
         desc=f"Cluster evolution for {zoom=}",
         delay=1,
     ):
         new_clusters = False
         # Current tile.
         tile = (row["tile_x"], row["tile_y"])
+
+        if tile in s.num_neighbors:
+            continue
 
         # This tile is new, therefore it doesn't have an entries in the neighbor list yet.
         s.num_neighbors[tile] = 0
@@ -598,11 +601,13 @@ def _compute_square_history(
 ) -> None:
     rows = []
     for index, row in tqdm(
-        tiles.iloc[s.square_start :].iterrows(),
+        tiles.iterrows(),
         desc=f"Square evolution for {zoom=}",
         delay=1,
     ):
         tile = (row["tile_x"], row["tile_y"])
+        if tile in s.visited_tiles:
+            continue
         x, y = tile
         s.visited_tiles.add(tile)
         for square_size in itertools.count(s.max_square_size + 1):


### PR DESCRIPTION
When importing a large Strava archive (via Strava API), an exception was thrown and there was no way to continue the import process.

The exception:

```
Exception in thread Thread-1 (importer_thread):
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/threading.py", line 1081, in _bootstrap_inner
    self._context.run(self.run)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.14/3.14.0_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/threading.py", line 1023, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./geo_activity_playground/webui/app.py", line 94, in importer_thread
    scan_for_activities(
    ~~~~~~~~~~~~~~~~~~~^
        repository, tile_visit_accessor, config, strava_begin, strava_end
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "./geo_activity_playground/webui/blueprints/upload_blueprint.py", line 127, in scan_for_activities
    import_from_strava_api(
    ~~~~~~~~~~~~~~~~~~~~~~^
        config, repository, tile_visit_accessor, strava_begin, strava_end
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "./geo_activity_playground/importers/strava_api.py", line 88, in import_from_strava_api
    while try_import_strava(
          ~~~~~~~~~~~~~~~~~^
        config, repository, tile_visit_accessor, strava_begin, strava_end
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ):
    ^
  File "./geo_activity_playground/importers/strava_api.py", line 203, in try_import_strava
    compute_tile_evolution(tile_visit_accessor.tile_state, config)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./geo_activity_playground/explorer/tile_visits.py", line 500, in compute_tile_evolution
    _compute_cluster_evolution(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^
        tile_history,
        ^^^^^^^^^^^^^
        tile_state["evolution_state"][zoom],
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        zoom,
        ^^^^^
    )
    ^
  File "./geo_activity_playground/explorer/tile_visits.py", line 568, in _compute_cluster_evolution
    other_cluster = s.clusters[s.memberships[other]]
                    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
KeyError: (70494, 43152)
```

With this change GAP now iterates over the full tiles set every run and use the state dictionaries (`s.num_neighbors`, `s.visited_tiles`) to short‑circuit already processed tiles. Previously the code sliced with `tiles.iloc[s.cluster_start:]` / `tiles.iloc[s.square_start:]`, assuming the tileset's RangeIndex would keep growing monotonically. After the importer thread rebuilt `tile_history` (fresh read from the DB, new RangeIndex starting at 0, potentially re‑ordered rows), those saved offsets pointed into the wrong portion of the set. That let previously processed tiles reappear in `_compute_cluster_evolution`.

When an old tile re-entered `_compute_cluster_evolution`, it was treated "as new", its neighbor count was reset and it could force clusters to be recreated or merged again. During those accidental replays the invariant "every `s.memberships[tile]` points to an entry in `s.clusters`" was violated: The replay could delete a cluster entry while some other tile still had its memberships pointer set to that cluster id. The next time it tried to join clusters, `s.clusters[s.memberships[other]]` raised the observed *KeyError*.

The new guards (`if tile in s.num_neighbors: continue` and `if tile in s.visited_tiles: continue`) make the state dictionaries the single source of truth for "was this tile processed already?". Even if the tileset index resets or rows arrive out of order, the cluster/square logic is never re-run for an old tile. So the cluster/membership mappings stay consistent and `s.clusters[...]` lookups no longer fail.

***

Disclaimer: Google Gemini chatbot supported me to get to the bottom of the error. Feel free to close this PR without further commenting if this violates a code of conduct or similar.